### PR TITLE
Set rts active high

### DIFF
--- a/BB-RS485-00A0.dts
+++ b/BB-RS485-00A0.dts
@@ -31,7 +31,7 @@
   };
 
   fragment@1 {
-    target = <&uart5>;
+    target = <&uart4>;
     __overlay__ {
       status = "okay";
       pinctrl-names = "default";

--- a/BB-RS485-00A0.dts
+++ b/BB-RS485-00A0.dts
@@ -39,7 +39,7 @@
       rs485-rts-delay = <0 0>;
 
       rts-gpio = <&gpio3 19 1>; /*  GPIO_ACTIVE_HIGH>; */
-
+      rs485-rts-active-high;
       linux,rs485-enabled-at-boot-time;
     };
   };


### PR DESCRIPTION
This flag seems to be needed in later kernel versions.
https://github.com/beagleboard/linux/blob/master/drivers/tty/serial/omap-serial.c#L1583
